### PR TITLE
Changes required for AWS to continue to run go lambda functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ The following information about this module is created via terraform-docs.
 ```hcl
 module "aws_iam_advisor" {
   source       = "KOTechnologiesLtd/iam-advisor/aws"
-  version      = "2.0.1"
+  version      = "2.0.3"
   ses_arn      = "arn:aws:ses:eu-west-2:XXXXXXXXXXXXXX:identity/XXXX@XXXXXXX.co.uk"
   sender_email = "XXXX@XXXXXXX.co.uk"
   admin_email  = "XXXX@XXXXXXX.co.uk"

--- a/aws-iam-advisor.tf
+++ b/aws-iam-advisor.tf
@@ -12,8 +12,8 @@ module "lambda_function" {
 
   function_name          = "aws-iam-advisor"
   description            = "AWS IAM Advisor"
-  handler                = "main"
-  runtime                = "go1.x"
+  handler                = "bootstrap"
+  runtime                = "provided.al2"
   memory_size            = "128"
   attach_policy_json     = true
   policy_json            = data.template_file.awsIamAdvisorPolicy.rendered

--- a/example/main.tf
+++ b/example/main.tf
@@ -1,6 +1,6 @@
 module "aws_iam_advisor" {
   source       = "KOTechnologiesLtd/iam-advisor/aws"
-  version      = "2.0.1"
+  version      = "2.0.3"
   ses_arn      = "arn:aws:ses:eu-west-2:XXXXXXXXXXXXXX:identity/XXXX@XXXXXXX.co.uk"
   sender_email = "XXXX@XXXXXXX.co.uk"
   admin_email  = "XXXX@XXXXXXX.co.uk"

--- a/policy/aws-iam-advisor.json
+++ b/policy/aws-iam-advisor.json
@@ -19,7 +19,8 @@
                 "iam:ListGroups",
                 "iam:ListMFADeviceTags",
                 "sts:GetSessionToken",
-                "iam:UpdateSigningCertificate"
+                "iam:UpdateSigningCertificate",
+                "iam:ListSigningCertificates"
             ],
             "Resource": "*"
         },


### PR DESCRIPTION
AWS require go lambda functions to now run in Amazon Linux 2. The binary produced should now be called bootstrap. This binary is used as the handler in the lambda function.